### PR TITLE
Dirty hack to support ?-notation nullable

### DIFF
--- a/lib/Parser/TypesParser.php
+++ b/lib/Parser/TypesParser.php
@@ -7,6 +7,14 @@ use Phpactor\Docblock\DocblockTypes;
 
 class TypesParser
 {
+    /**
+     * Mask to remove white space and nullable prefixes(?)
+     *
+     * The current Phpactor's type system doesn't handle "nullable",
+     * it just erases at the same time as white space.
+     */
+    private const MASK_WHITESPACE_AND_IGNORED_PREFIX = "? \t\n\r\0\x0B";
+
     public function parseTypes(string $types): DocblockTypes
     {
         if (empty($types)) {
@@ -17,17 +25,17 @@ class TypesParser
         $docblockTypes = [];
 
         foreach (explode('|', $types) as $type) {
-            $type = trim($type, "? \t\n\r\0\x0B");
+            $type = trim($type, self::MASK_WHITESPACE_AND_IGNORED_PREFIX);
 
             if (preg_match('{^(.*)<(.*)>$}', $type, $matches)) {
                 $type = $matches[1];
-                $collectionType = trim($matches[2], "? \t\n\r\0\x0B");
+                $collectionType = trim($matches[2], self::MASK_WHITESPACE_AND_IGNORED_PREFIX);
                 $docblockTypes[] = DocblockType::collectionOf($type, $collectionType);
                 continue;
             }
 
             if (substr($type, -2) == '[]') {
-                $type = trim(substr($type, 0, -2), "? \t\n\r\0\x0B");;
+                $type = trim(substr($type, 0, -2), self::MASK_WHITESPACE_AND_IGNORED_PREFIX);
                 $docblockTypes[] = DocblockType::arrayOf($type);
                 continue;
             }

--- a/lib/Parser/TypesParser.php
+++ b/lib/Parser/TypesParser.php
@@ -14,21 +14,20 @@ class TypesParser
         }
 
         $types = str_replace('&', '|', $types);
-        $types = explode('|', $types);
         $docblockTypes = [];
 
-        foreach ($types as $type) {
-            $type = trim($type);
+        foreach (explode('|', $types) as $type) {
+            $type = trim($type, "? \t\n\r\0\x0B");
 
             if (preg_match('{^(.*)<(.*)>$}', $type, $matches)) {
                 $type = $matches[1];
-                $collectionType = $matches[2];
+                $collectionType = trim($matches[2], "? \t\n\r\0\x0B");
                 $docblockTypes[] = DocblockType::collectionOf($type, $collectionType);
                 continue;
             }
 
             if (substr($type, -2) == '[]') {
-                $type = substr($type, 0, -2);
+                $type = trim(substr($type, 0, -2), "? \t\n\r\0\x0B");;
                 $docblockTypes[] = DocblockType::arrayOf($type);
                 continue;
             }

--- a/tests/Parser/TypesParserTest.php
+++ b/tests/Parser/TypesParserTest.php
@@ -37,6 +37,18 @@ class TypesParserTest extends TestCase
                 '\Foobar\Foobar',
                 DocblockTypes::fromDocblockTypes([ DocblockType::fullyQualifiedNameOf('Foobar\Foobar') ]),
             ],
+            [
+                '?Foobar',
+                DocblockTypes::fromStringTypes(['Foobar']),
+            ],
+            [
+                '?Foobar[]',
+                DocblockTypes::fromDocblockTypes([ DocblockType::arrayOf('Foobar') ]),
+            ],
+            [
+                'Foobar<?Item>',
+                DocblockTypes::fromDocblockTypes([ DocblockType::collectionOf('Foobar', 'Item') ]),
+            ],
         ];
     }
 }


### PR DESCRIPTION
The purpose of this patch is just to make nullable written in DocComment work.

This treats nullable as equivalent to non-nullable notation by simply erasing `?`.  `?Klass` should be treated as `Klass|null`, but will only be turned off in this patch.  This is because the current
Phpactor does not have a recursive type and cannot represent `?string[]` (same as `array<string|null>`).

Recently, complex notations like array-shapes have been incorporated into the de facto, so you might want to incorporate another implementation like <https://github.com/phpstan/phpdoc-parser>.