### PR TITLE
PHPDoc parser supports ?-notation nullable prefix

### DIFF
--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -4,7 +4,7 @@ namespace Phpactor\Docblock;
 
 class Parser
 {
-    const TAG = '{@([-0-9A-Z_a-z\\\\]+)\s*?([$&(),<=>\[\\\\\]|\w\s]+)?}';
+    const TAG = '{@([-0-9A-Z_a-z\\\\]+)\s*?([$&(),<=>?\[\\\\\]|\w\s]+)?}';
 
     public function parse($docblock): array
     {

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -4,7 +4,7 @@ namespace Phpactor\Docblock;
 
 class Parser
 {
-    const TAG = '{@([a-zA-Z0-9-_\\\]+)\s*?([\\<\\>\\[\\]&|,\\\(\\\)$\w\s=]+)?}';
+    const TAG = '{@([-0-9A-Z_a-z\\\\]+)\s*?([$&(),<=>\[\\\\\]|\w\s]+)?}';
 
     public function parse($docblock): array
     {

--- a/tests/DocblockFactoryTest.php
+++ b/tests/DocblockFactoryTest.php
@@ -71,6 +71,10 @@ class DocblockFactoryTest extends TestCase
                 '/** @return Foobar foobar() */',
                 Docblock::fromTags([ new ReturnTag(DocblockTypes::fromStringTypes([ 'Foobar' ])) ]),
             ],
+            'return single nullable type' => [
+                '/** @return ?Foobar foobar() */',
+                Docblock::fromTags([ new ReturnTag(DocblockTypes::fromStringTypes([ 'Foobar' ])) ]),
+            ],
             'inheritdoc' => [
                 '/** {@inheritDoc} */',
                 Docblock::fromTags([ new InheritTag() ]),


### PR DESCRIPTION
refs #3 

This PR has regexp optimization, not just adding `?`.

## Optimize PCRE regexp pattern

 - Move `-` to the beginning of `[]`.
   This is a convention for clarifying that-does not represent range.
 - When representing `\` in the regexp pattern, place four `\` instead of three.
   This is because the evaluation result is the same, but it does not unbalance the number of `\` in the single quoted string.
   There is only one `\` except for `"\\"` and `"\'"`, which have the role of escape, in a single quote literal.
 - Arrange characters in character class `[]` in ASCII order.
 - Do not escape characters that do not have special features in the character class `[]`.  Special characters are `[`, `]`, `^` and `-`.