### PR TITLE
Add support for @link tags

### DIFF
--- a/lib/DocblockFactory.php
+++ b/lib/DocblockFactory.php
@@ -5,6 +5,7 @@ namespace Phpactor\Docblock;
 use Phpactor\Docblock\Parser\MethodParser;
 use Phpactor\Docblock\Parser\TypesParser;
 use Phpactor\Docblock\Tag\DeprecatedTag;
+use Phpactor\Docblock\Tag\LinkTag;
 use Phpactor\Docblock\Tag\MethodTag;
 use Phpactor\Docblock\Tag\MixinTag;
 use Phpactor\Docblock\Tag\ParamTag;
@@ -63,6 +64,9 @@ class DocblockFactory
                         break;
                     case 'return':
                         $tags[] = $this->createReturnTag($metadata);
+                        break;
+                    case 'link':
+                        $tags[] = $this->createLinkTag($metadata);
                         break;
                     case 'inheritdoc':
                         $tags[] = new InheritTag();
@@ -130,6 +134,17 @@ class DocblockFactory
     private function createDeprecatedTag(array $metadata): DeprecatedTag
     {
         return new DeprecatedTag(implode(' ', $metadata));
+    }
+
+    /**
+     * @param string[] $metadata
+     */
+    private function createLinkTag(array $metadata): LinkTag
+    {
+        $link = array_shift($metadata);
+        $label = $metadata[0] ?? null;
+
+        return new LinkTag($link, $label);
     }
 
     private function createMixinTag(array $metadata): ?MixinTag

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -4,7 +4,7 @@ namespace Phpactor\Docblock;
 
 class Parser
 {
-    const TAG = '{@([-0-9A-Z_a-z\\\\]+)\s*?([$&(),<=>?\[\\\\\]|\w\s]+)?}';
+    const TAG = '{@([-0-9A-Z_a-z\\\\]+)\s*?([$&(),<=>?\[\\\\\]|\w\s:\./\-\_]+)?}';
 
     public function parse($docblock): array
     {

--- a/lib/Tag/LinkTag.php
+++ b/lib/Tag/LinkTag.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Phpactor\Docblock\Tag;
+
+use Phpactor\Docblock\Tag;
+
+class LinkTag implements Tag
+{
+    /**
+     * @var string
+     */
+    private $link;
+
+    /**
+     * @var ?string
+     */
+    private $label;
+
+    public function __construct(string $link, ?string $label)
+    {
+        $this->link = $link;
+        $this->label = $label;
+    }
+
+    public function name(): string
+    {
+        return 'link';
+    }
+
+    public function link(): string
+    {
+        return $this->link;
+    }
+
+    public function label(): ?string
+    {
+        return $this->label;
+    }
+}

--- a/tests/DocblockFactoryTest.php
+++ b/tests/DocblockFactoryTest.php
@@ -4,16 +4,17 @@ namespace Phpactor\Docblock\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Phpactor\Docblock\Docblock;
-use Phpactor\Docblock\Tag\DeprecatedTag;
-use Phpactor\Docblock\Tag\MixinTag;
-use Phpactor\Docblock\Tag\PropertyTag;
-use Phpactor\Docblock\Tag\VarTag;
 use Phpactor\Docblock\DocblockFactory;
-use Phpactor\Docblock\Tag\ParamTag;
-use Phpactor\Docblock\Tag\MethodTag;
 use Phpactor\Docblock\DocblockTypes;
-use Phpactor\Docblock\Tag\ReturnTag;
 use Phpactor\Docblock\InheritTag;
+use Phpactor\Docblock\Tag\DeprecatedTag;
+use Phpactor\Docblock\Tag\LinkTag;
+use Phpactor\Docblock\Tag\MethodTag;
+use Phpactor\Docblock\Tag\MixinTag;
+use Phpactor\Docblock\Tag\ParamTag;
+use Phpactor\Docblock\Tag\PropertyTag;
+use Phpactor\Docblock\Tag\ReturnTag;
+use Phpactor\Docblock\Tag\VarTag;
 
 class DocblockFactoryTest extends TestCase
 {
@@ -106,6 +107,14 @@ class DocblockFactoryTest extends TestCase
                 '/** @mixin Foobar\\Barfoo */',
                 Docblock::fromTags([ new MixinTag('Foobar\\Barfoo') ]),
             ],
+            'link without label' => [
+                '/** @link https://example.org */',
+                Docblock::fromTags([ new LinkTag("https://example.org", null) ])
+            ],
+            'link with label' => [
+                '/** @link https://example.org Example */',
+                Docblock::fromTags([ new LinkTag("https://example.org", "Example") ])
+            ]
         ];
     }
 }


### PR DESCRIPTION
This adds support for `@link` tags.

In order to correctly parse php.net links correctly I had to add more characters to Parser::TAG constant regex.

Tests are running fine, so I hope it won't create.

_This is a part of the larger change set I'm planning to add to other repositories to be able to show links in the LSP hover popup._

![image](https://user-images.githubusercontent.com/2505114/145594380-55a34c64-3a56-443f-babf-d7400e5ced48.png)
